### PR TITLE
Fix indexer error handling DrawDebt operation

### DIFF
--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -3,7 +3,7 @@ import { Address, BigDecimal, BigInt, Bytes, dataSource, log } from "@graphproto
 import { Bucket, Lend } from "../../generated/schema"
 import { PoolInfoUtils } from '../../generated/templates/ERC20Pool/PoolInfoUtils'
 
-import { ZERO_BD, poolInfoUtilsNetworkLookUpTable } from "./constants"
+import { ONE_BD, ZERO_BD, poolInfoUtilsNetworkLookUpTable } from "./constants"
 import { bigDecimalWadToBigInt, wadToDecimal } from "./convert"
 
 export function lpbValueInQuote(pool: Bytes, bucketIndex: u32, lpAmount: BigDecimal): BigDecimal {
@@ -30,8 +30,12 @@ export function collateralization(debt: BigDecimal, encumberedCollateral: BigDec
 
 // TODO: check for precision loss
 export function collateralizationAtLup(debt: BigDecimal, collateral: BigDecimal, lup: BigDecimal): BigDecimal {
-    const encumberedCollateral = debt.div(lup)
-    return debt.div(encumberedCollateral)
+    if (debt > ZERO_BD && lup > ZERO_BD) {
+      const encumberedCollateral = debt.div(lup)
+      return debt.div(encumberedCollateral)
+    } else {
+      return ONE_BD
+    }
 }
 
 export function thresholdPrice(debt: BigDecimal, collateral: BigDecimal): BigDecimal {


### PR DESCRIPTION
Handle case where borrower pledges and draws in separate TXes.  Without this, was getting divide-by-zero error from [this TX](https://goerli.etherscan.io/tx/0xe3535a913aaf1de103ca3a6f02d5b38d0c6455f8e4859a3eccf713072bf7d4c8).