### PR TITLE
Populate non-nullable fields for LP NFT Token entities

### DIFF
--- a/src/position-manager.ts
+++ b/src/position-manager.ts
@@ -150,7 +150,7 @@ export function handleRedeemPosition(event: RedeemPositionEvent): void {
 }
 
 export function handleTransfer(event: TransferEvent): void {
-  let entity = new Transfer(
+  const entity = new Transfer(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   )
   entity.from = event.params.from
@@ -158,11 +158,13 @@ export function handleTransfer(event: TransferEvent): void {
   entity.tokenId = event.params.tokenId
   entity.pool = getPoolForToken(entity.tokenId)
 
-  entity.token = loadOrCreateLPToken(event.address).id
+  const token = loadOrCreateLPToken(event.address)
+  entity.token = token.id
 
   entity.blockNumber = event.block.number
   entity.blockTimestamp = event.block.timestamp
   entity.transactionHash = event.transaction.hash
 
+  token.save();
   entity.save()
 }

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, dataSource } from "@graphprotocol/graph-ts"
+import { Address, BigInt, dataSource, log } from "@graphprotocol/graph-ts"
 
 import { Token } from "../../generated/schema"
 import { ONE_BI, ZERO_BI, positionManagerNetworkLookUpTable } from "../utils/constants"
@@ -9,14 +9,15 @@ import { PositionManager } from "../../generated/PositionManager/PositionManager
 export function loadOrCreateLPToken(tokenAddress: Address): Token {
   const id = addressToBytes(tokenAddress)
   let token = Token.load(id)
-  if (token == null) {
-    // create new account if account hasn't already been stored
+  if (token == null) {    
     token = new Token(id) as Token
     token.name        = getTokenName(tokenAddress)
+    token.decimals    = ZERO_BI
     token.symbol      = getTokenSymbol(tokenAddress)
     token.txCount     = ZERO_BI
     token.isERC721    = true
     token.poolCount   = ONE_BI
+    token.totalSupply = ONE_BI
   }
 
   return token


### PR DESCRIPTION
Resolve bug creating LP Token entities.  Notice the entity isn't very useful yet because we have not properly modeled NFT tokens, and there is no mapping from the token to the pool.

This bug was causing the following query to fail...
```
{
  transfers{
    tokenId
    token {
      id
    }
  }
}
```
...with this kind of response:
```
{
  "errors": [
    {
      "locations": [
        {
          "line": 4,
          "column": 5
        }
      ],
      "message": "Null value resolved for non-null field `token`"
    },
```