### PR TITLE
Preparations for ERC721 pools

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,4 @@
 # TODO: track approvals?
-# TODO: finish expanding this schema -> ERC20 / ERC721?
 # TODO: track token liquidity across all Ajna pools
 # this supports both ERC20 and ERC721 tokens, as union types aren't currently supported
 type Token @entity {
@@ -11,9 +10,8 @@ type Token @entity {
   name: String!
   # token decimals
   decimals: Int!
-  # flag for whether the token is an ERC721
-  # TODO: make this a string, enabling new pool types (such as ERC1155)
-  isERC721: Boolean!
+  # indicates whether the token is ERC20 or ERC721
+  tokenType: String!
   # number of pools including this token
   poolCount: BigInt!
   # total supply of the token
@@ -22,9 +20,11 @@ type Token @entity {
   txCount: BigInt!
 }
 
-type ERC20PoolFactory @entity {
+type PoolFactory @entity {
   # factory address
   id: Bytes!
+  # indicates type of collateral (ERC20 or ERC721)
+  poolType: String!
   # number of pools deployed by the factory
   poolCount: BigInt!
   # list of pools deployed by the factory
@@ -609,7 +609,9 @@ type Transfer @entity(immutable: true) {
 
 type PoolCreated @entity(immutable: true) {
   id: Bytes!
-  pool: Bytes!        # address
+  pool: Pool!           # pool which was created
+  poolType: String!     # ERC20 or ERC721
+  factory: PoolFactory! # address of factory contract used to create pool
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!

--- a/src/erc-721-pool-factory.ts
+++ b/src/erc-721-pool-factory.ts
@@ -1,19 +1,26 @@
 import { PoolCreated as PoolCreatedEvent } from "../generated/ERC721PoolFactory/ERC721PoolFactory"
-import { PoolCreated } from "../generated/schema"
+import { Pool, PoolCreated, Token } from "../generated/schema"
+import { ONE_BI } from "./utils/constants"
+import { loadOrCreateFactory } from "./utils/pool-factory"
 
 export function handlePoolCreated(event: PoolCreatedEvent): void {
   const poolCreated = new PoolCreated(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   )
   poolCreated.pool = event.params.pool_
+  poolCreated.poolType = "ERC721"
+  poolCreated.factory = event.address;
 
   poolCreated.blockNumber = event.block.number
   poolCreated.blockTimestamp = event.block.timestamp
   poolCreated.transactionHash = event.transaction.hash
 
+  // record factory information
+  let factory = loadOrCreateFactory(event.address, "ERC20")
+  factory.poolCount = factory.poolCount.plus(ONE_BI)
+  factory.txCount   = factory.txCount.plus(ONE_BI)
+
   // TODO: 
-  // - record factory information
-  // - increment pool count
   // - instantiate pool contract
   // - get pool initial interest rate
   // - create Token entites associated with the pool

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -24,10 +24,6 @@ export const MIN_BUCKET_INDEX = -3232;
 export const MAX_BUCKET_INDEX = 4156;
 
 // Pool addresses per network
-export const erc20FactoryAddressTable = new TypedMap<string, Address>()
-erc20FactoryAddressTable.set('mainnet', Address.fromString('0xe6F4d9711121e5304b30aC2Aae57E3b085ad3c4d'))
-erc20FactoryAddressTable.set('goerli', Address.fromString('0x01Da8a85A5B525D476cA2b51e44fe7087fFafaFF'))
-erc20FactoryAddressTable.set('ganache', Address.fromString('0xD86c4A8b172170Da0d5C0C1F12455bA80Eaa42AD'))
 export const poolInfoUtilsAddressTable = new TypedMap<string, Address>()
 poolInfoUtilsAddressTable.set('mainnet', Address.fromString('0x154FFf344f426F99E328bacf70f4Eb632210ecdc'))
 poolInfoUtilsAddressTable.set('goerli', Address.fromString('0xBB61407715cDf92b2784E9d2F1675c4B8505cBd8'))

--- a/src/utils/pool-factory.ts
+++ b/src/utils/pool-factory.ts
@@ -1,0 +1,18 @@
+import { Address } from "@graphprotocol/graph-ts"
+import { PoolFactory } from "../../generated/schema"
+
+import { ZERO_BI } from "./constants"
+
+export function loadOrCreateFactory(address: Address, poolType: string): PoolFactory {
+  let factory = PoolFactory.load(address)
+  if (factory == null) {
+    // create new account if account hasn't already been stored
+    factory = new PoolFactory(address) as PoolFactory
+    factory.poolType = poolType
+    factory.poolCount = ZERO_BI
+    factory.pools     = []
+    factory.txCount   = ZERO_BI
+  }
+
+  return factory
+}

--- a/src/utils/position.ts
+++ b/src/utils/position.ts
@@ -17,7 +17,7 @@ export function loadOrCreateLPToken(tokenAddress: Address): Token {
     token.decimals    = 0
     token.symbol      = getTokenSymbol(tokenAddress)
     token.txCount     = ZERO_BI
-    token.isERC721    = true
+    token.tokenType   = "ERC721"
     token.poolCount   = ONE_BI
     token.totalSupply = ONE_BI
   }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,8 +6,8 @@ dataSources:
     name: PositionManager
     source:
       abi: PositionManager
-      address: "0x37048D43A65748409B04f4051eEd9480BEf68c82"
-      startBlock: 9289397
+      address: "0x6c5c7fD98415168ada1930d44447790959097482"
+      startBlock: 0
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -46,13 +46,13 @@ dataSources:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
       file: ./src/position-manager.ts
-    network: goerli
+    network: ganache
   - kind: ethereum
     name: ERC20PoolFactory
     source:
       abi: ERC20PoolFactory
-      address: "0x01Da8a85A5B525D476cA2b51e44fe7087fFafaFF"
-      startBlock: 9289397
+      address: "0xD86c4A8b172170Da0d5C0C1F12455bA80Eaa42AD"
+      startBlock: 0
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -72,13 +72,13 @@ dataSources:
         - event: PoolCreated(address)
           handler: handlePoolCreated
       file: ./src/erc-20-pool-factory.ts
-    network: goerli
+    network: ganache
   - kind: ethereum
     name: RewardsManager
     source:
       abi: RewardsManager
-      address: "0x994dE190dd763Af3126FcC8EdC139275937d800b"
-      startBlock: 9289397
+      address: "0x6548dF23A854f72335902e58a1e59B50bb3f11F1"
+      startBlock: 0
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -107,13 +107,13 @@ dataSources:
         - event: UpdateExchangeRates(indexed address,indexed address,uint256[],uint256)
           handler: handleUpdateExchangeRates
       file: ./src/rewards-manager.ts
-    network: goerli
+    network: ganache
   - kind: ethereum
     name: ERC721PoolFactory
     source:
       abi: ERC721PoolFactory
-      address: "0x37048D43A65748409B04f4051eEd9480BEf68c82"
-      startBlock: 9289397
+      address: "0x9617ABE221F9A9c492D5348be56aef4Db75A692d"
+      startBlock: 0
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -131,13 +131,13 @@ dataSources:
         - event: PoolCreated(address)
           handler: handlePoolCreated
       file: ./src/erc-721-pool-factory.ts
-    network: goerli
+    network: ganache
   - kind: ethereum
     name: GrantFund
     source:
       abi: GrantFund
-      address: "0x881b4dFF6C72babA6f5eA60f34A61410c1EA1ec2"
-      startBlock: 9297080
+      address: "0xE340B87CEd1af1AbE1CE8D617c84B7f168e3b18b"
+      startBlock: 0
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
@@ -169,7 +169,7 @@ dataSources:
         - event: VoteCast(indexed address,uint256,uint8,uint256,string)
           handler: handleVoteCast
       file: ./src/grant-fund.ts
-    network: goerli
+    network: ganache
 templates:
   - kind: ethereum
     name: ERC20Pool
@@ -273,4 +273,4 @@ templates:
         - event: UpdateInterestRate(uint256,uint256)
           handler: handleUpdateInterestRate
       file: ./src/erc-20-pool.ts
-    network: goerli
+    network: ganache

--- a/tests/erc-20-pool-factory.test.ts
+++ b/tests/erc-20-pool-factory.test.ts
@@ -11,7 +11,7 @@ import {
 import { Address, BigInt, dataSource } from "@graphprotocol/graph-ts"
 import { createPool, mockGetRatesAndFees } from "./utils/common"
 
-import { FIVE_PERCENT_BI, MAX_PRICE, ONE_BI, ZERO_BI, erc20FactoryAddressTable } from "../src/utils/constants"
+import { FIVE_PERCENT_BI, MAX_PRICE, ONE_BI, ZERO_BI } from "../src/utils/constants"
 
 // Tests structure (matchstick-as >=0.5.0)
 // https://thegraph.com/docs/en/developer/matchstick/#tests-structure-0-5-0
@@ -56,17 +56,23 @@ describe("ERC20PoolFactory assertions", () => {
   })
 
   test("Factory entity attributes", () => {
-    assert.entityCount("ERC20PoolFactory", 1)
+    assert.entityCount("PoolFactory", 1)
   
-    const erc20factoryAddress = erc20FactoryAddressTable.get(dataSource.network())!
+    const erc20factoryAddress = Address.fromString("0x0000000000000000000000000000000000002020")
     assert.fieldEquals(
-      "ERC20PoolFactory",
+      "PoolFactory",
+      erc20factoryAddress.toHexString(),
+      "poolType",
+      "ERC20"
+    )
+    assert.fieldEquals(
+      "PoolFactory",
       erc20factoryAddress.toHexString(),
       "poolCount",
       `${ONE_BI}`
     )
     assert.fieldEquals(
-      "ERC20PoolFactory",
+      "PoolFactory",
       erc20factoryAddress.toHexString(),
       "txCount",
       `${ONE_BI}`

--- a/tests/utils/common.ts
+++ b/tests/utils/common.ts
@@ -340,6 +340,7 @@ export function createPool(pool_: Address, collateral: Address, quote: Address, 
 
     // mock PoolCreated event
     const newPoolCreatedEvent = createPoolCreatedEvent(pool_)
+    newPoolCreatedEvent.address = Address.fromString("0x0000000000000000000000000000000000002020")
     handlePoolCreated(newPoolCreatedEvent)
 }
 


### PR DESCRIPTION
**Changes**
- Cleaned up the schema to use a single factory object.
- Identify token type and pool type using a `String`.
- Eliminate factory address table from constants.

This enables queries like the following:
![image](https://github.com/ajna-finance/subgraph/assets/46749157/506769d4-568a-4673-a10d-ca5cabc22d1e)
