### PR TITLE
correct lendRate calculation (dev)

### DIFF
--- a/src/erc-20-pool-factory.ts
+++ b/src/erc-20-pool-factory.ts
@@ -14,7 +14,6 @@ import {
 } from "./utils/constants"
 import { addressToBytes, wadToDecimal } from "./utils/convert"
 import { getTokenDecimals, getTokenName, getTokenSymbol, getTokenTotalSupply } from "./utils/token-erc20"
-import { wmul } from "./utils/math"
 import { getRatesAndFees } from "./utils/pool"
 import { loadOrCreateFactory } from "./utils/pool-factory"
 
@@ -86,7 +85,7 @@ export function handlePoolCreated(event: PoolCreatedEvent): void {
   pool.t0debt = ZERO_BD
   pool.inflator = ONE_BD
   pool.borrowRate = wadToDecimal(interestRateResults.value0)
-  pool.lendRate = wadToDecimal(wmul(interestRateResults.value0, ratesAndFees.lenderInterestMargin))
+  pool.lendRate = ZERO_BD
   pool.borrowFeeRate = wadToDecimal(ratesAndFees.borrowFeeRate)
   pool.depositFeeRate = wadToDecimal(ratesAndFees.depositFeeRate)
   pool.pledgedCollateral = ZERO_BD


### PR DESCRIPTION
`lendRate` calculation was not taking utilization into account per https://github.com/ajna-finance/contracts/blob/master/src/libraries/external/PoolCommons.sol#L247 .
Eliminate redundant calculation handling interest rate reset and update events.

Note that `lendRate` will now always be 0 until after debt is drawn from the pool.