### PR TITLE
associate bucket with Pool entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -123,6 +123,8 @@ type Bucket @entity {
   bucketPrice: BigDecimal!
   # current exchange rate of the bucket
   exchangeRate: BigDecimal!
+  # pool address
+  poolAddress: String!
   # pool in which the bucket belongs
   pool: Pool!
   # total collateral available in the bucket

--- a/src/utils/pool/bucket.ts
+++ b/src/utils/pool/bucket.ts
@@ -55,6 +55,7 @@ export function loadOrCreateBucket(poolId: Bytes, bucketId: Bytes, index: u32): 
 
       bucket.bucketIndex  = index
       bucket.bucketPrice  = indexToPrice(index)
+      bucket.poolAddress  = poolId.toHexString()
       bucket.pool         = poolId
       bucket.collateral   = ZERO_BD
       bucket.deposit      = ZERO_BD


### PR DESCRIPTION
Currently two queries are needed to inspect the `Pool` associated with a `Bucket`.  Enabling a single query to get pool data is useful for a few cases:
- identifying pools with deposit in first bucket
- showing available collateral sitting in pools ready to be traded
- revealing pools with free collateral placed in bucket 7388 as a result of liquidation